### PR TITLE
Upgrade TensorFlow to v2

### DIFF
--- a/modules/deepspell/models/discriminator.py
+++ b/modules/deepspell/models/discriminator.py
@@ -4,6 +4,7 @@
 
 import numpy as np
 import tensorflow as tf
+tf.compat.v1.disable_eager_execution()
 import math
 from collections import defaultdict
 
@@ -108,8 +109,8 @@ class DSLstmDiscriminator(modelbase.DSModelBase):
                                                            :, :, :self.num_lexical_features]
 
             # -- Backward pass
-            tf_discriminator_backward_cell = tf.contrib.rnn.MultiRNNCell([
-                tf.contrib.rnn.BasicLSTMCell(hidden_state_size) for hidden_state_size in
+            tf_discriminator_backward_cell = tf.compat.v1.nn.rnn_cell.MultiRNNCell([
+                tf.compat.v1.nn.rnn_cell.BasicLSTMCell(hidden_state_size) for hidden_state_size in
                 self.bw_state_size_per_layer])
             tf_backward_embeddings_per_timestep_per_batch, _ = tf.nn.dynamic_rnn(
                 cell=tf_discriminator_backward_cell,
@@ -120,9 +121,9 @@ class DSLstmDiscriminator(modelbase.DSModelBase):
                 time_major=False)
 
             # -- Forward pass
-            tf_discriminator_forward_cell = tf.contrib.rnn.OutputProjectionWrapper(
-                tf.contrib.rnn.MultiRNNCell([
-                    tf.contrib.rnn.BasicLSTMCell(hidden_state_size) for hidden_state_size in
+            tf_discriminator_forward_cell = tf.compat.v1.nn.rnn_cell.OutputProjectionWrapper(
+                tf.compat.v1.nn.rnn_cell.MultiRNNCell([
+                    tf.compat.v1.nn.rnn_cell.BasicLSTMCell(hidden_state_size) for hidden_state_size in
                     self.fw_state_size_per_layer
                 ]),
                 self.num_logical_features)

--- a/modules/deepspell/models/encoder.py
+++ b/modules/deepspell/models/encoder.py
@@ -15,6 +15,7 @@ except ImportError:
     pass
 
 import tensorflow as tf
+tf.compat.v1.disable_eager_execution()
 import numpy as np
 
 # ============================[ Local Imports ]==========================
@@ -143,18 +144,18 @@ class DSVariationalLstmAutoEncoder(modelbase.DSModelBase):
         with tf.name_scope("encoder"):
 
             # -- Slice lexical features from lexical-logical input
-            tf_corrupt_encoder_input = tf.placeholder(
+            tf_corrupt_encoder_input = tf.compat.v1.placeholder(
                 tf.float32,
                 [None, None, self.num_lexical_features])
 
-            tf_encoder_backward_cell = tf.contrib.rnn.MultiRNNCell([
-                tf.contrib.rnn.BasicLSTMCell(hidden_state_size) for hidden_state_size in
+            tf_encoder_backward_cell = tf.compat.v1.nn.rnn_cell.MultiRNNCell([
+                tf.compat.v1.nn.rnn_cell.BasicLSTMCell(hidden_state_size) for hidden_state_size in
                 self.encoder_bw_state_size_per_layer])
-            tf_encoder_forward_cell = tf.contrib.rnn.MultiRNNCell([
-                tf.contrib.rnn.BasicLSTMCell(hidden_state_size) for hidden_state_size in
+            tf_encoder_forward_cell = tf.compat.v1.nn.rnn_cell.MultiRNNCell([
+                tf.compat.v1.nn.rnn_cell.BasicLSTMCell(hidden_state_size) for hidden_state_size in
                 self.encoder_fw_state_size_per_layer])
-            tf_encoder_combine_cell = tf.contrib.rnn.MultiRNNCell([
-                tf.contrib.rnn.BasicLSTMCell(hidden_state_size) for hidden_state_size in
+            tf_encoder_combine_cell = tf.compat.v1.nn.rnn_cell.MultiRNNCell([
+                tf.compat.v1.nn.rnn_cell.BasicLSTMCell(hidden_state_size) for hidden_state_size in
                 self.encoder_combine_state_size_per_layer])
 
             # -- Create a dynamically unrolled RNN to produce the character category discrimination
@@ -184,13 +185,13 @@ class DSVariationalLstmAutoEncoder(modelbase.DSModelBase):
         :return: tf_latent_mean, tf_latent_variance, tf_latent_vec
         """
         with tf.variable_scope('encoder_to_latent'):
-            kl_rate = tf.placeholder(tf.float32, shape=[])
+            kl_rate = tf.compat.v1.placeholder(tf.float32, shape=[])
             concat_state_size = 2*sum(self.encoder_combine_state_size_per_layer)
             w = tf.get_variable("w", [concat_state_size, 2 * self.embedding_size], dtype=tf.float32)
             b = tf.get_variable("b", [2 * self.embedding_size], dtype=tf.float32)
             mean_logvar = self._prelu(tf.matmul(self.tf_encoder_final_state_per_batch, w) + b)
             means, logvar = tf.split(mean_logvar, num_or_size_splits=2, axis=1)
-            noise = tf.random_normal(tf.shape(means)) * kl_rate
+            noise = tf.random.normal(tf.shape(means)) * kl_rate
             sampled_random_vectors = means + tf.exp(0.5 * logvar) * noise
             kl_loss = tf.reshape(
                 tf.reduce_mean(-0.5 * (logvar - tf.square(means) - tf.exp(logvar) + 1.0),),
@@ -198,5 +199,5 @@ class DSVariationalLstmAutoEncoder(modelbase.DSModelBase):
             # if kl_min:
             #     kl_loss = tf.reduce_sum(tf.maximum(kl_ave, kl_min))
             kl_loss *= kl_rate
-            kl_loss_summary = tf.summary.scalar("kl_loss", kl_loss)
+            kl_loss_summary = tf.compat.v1.summary.scalar("kl_loss", kl_loss)
         return sampled_random_vectors, means, kl_loss, kl_loss_summary, kl_rate

--- a/modules/deepspell/models/extrapolator.py
+++ b/modules/deepspell/models/extrapolator.py
@@ -4,6 +4,7 @@
 
 import numpy as np
 import tensorflow as tf
+tf.compat.v1.disable_eager_execution()
 
 # ============================[ Local Imports ]==========================
 
@@ -130,9 +131,9 @@ class DSLstmExtrapolator(modelbase.DSModelBase):
         with tf.name_scope("extrapolator"):
 
             # -- LSTM cell for prediction
-            tf_extrapolator_cell = tf.contrib.rnn.OutputProjectionWrapper(
-                tf.contrib.rnn.MultiRNNCell([
-                    tf.contrib.rnn.BasicLSTMCell(hidden_state_size) for hidden_state_size in
+            tf_extrapolator_cell = tf.compat.v1.nn.rnn_cell.OutputProjectionWrapper(
+                tf.compat.v1.nn.rnn_cell.MultiRNNCell([
+                    tf.compat.v1.nn.rnn_cell.BasicLSTMCell(hidden_state_size) for hidden_state_size in
                     self.state_size_per_layer
                 ]),
                 self.num_logical_features + self.num_lexical_features
@@ -155,8 +156,8 @@ class DSLstmExtrapolator(modelbase.DSModelBase):
 
     def _stepwise_beam_extrapolator(self):
         with tf.name_scope("stepwise_beam_extrapolator"):
-            tf_maximum_prediction_length = tf.placeholder(tf.int32)
-            tf_eol_class_idx = tf.placeholder(tf.int32)
+            tf_maximum_prediction_length = tf.compat.v1.placeholder(tf.int32)
+            tf_eol_class_idx = tf.compat.v1.placeholder(tf.int32)
             tf_stepwise_beam_output = tf.TensorArray(dtype=tf.int32, size=1, dynamic_size=True)
             # tf_stepwise_debug_output = tf.TensorArray(dtype=tf.int32, size=tf_maximum_prediction_length-1)
             tf_beam_lexical_lookup_idx = tf.constant([
@@ -178,7 +179,7 @@ class DSLstmExtrapolator(modelbase.DSModelBase):
             tf_first_logical_class = tf.argmax(
                 self.tf_lexical_logical_predictions_per_timestep_per_batch[0, -1, -self.num_logical_features:])
             tf_beam_state_stack = tuple(
-                tf.contrib.rnn.LSTMStateTuple(
+                tf.compat.v1.nn.rnn_cell.LSTMStateTuple(
                     tf.tile(state_tuple.c, [self.extrapolation_beam_count, 1]),
                     tf.tile(state_tuple.h, [self.extrapolation_beam_count, 1])
                 ) for state_tuple in self.tf_extrapolator_final_state_tuple_stack)
@@ -189,7 +190,7 @@ class DSLstmExtrapolator(modelbase.DSModelBase):
                 tf.reshape(tf.tile([tf.cast(tf_first_logical_class, tf.int32)], [self.extrapolation_beam_count]), shape=(-1, 1))  # Always adapt best class for all beams
             ], axis=1)
             tf_stepwise_beam_output = tf_stepwise_beam_output.write(0, tf_beam_tails)
-            tf_beam_probs = tf.log(tf_beam_probs)  # Current log-prob for each beam
+            tf_beam_probs = tf.math.log(tf_beam_probs)  # Current log-prob for each beam
 
             #  Per-beam per-step log-prob factor for each beam. Will be set to 0 when a beam encounters EOL.
             tf_unfinished_beams = tf.tile([True], [self.extrapolation_beam_count])
@@ -208,7 +209,7 @@ class DSLstmExtrapolator(modelbase.DSModelBase):
                 unfinished_beam_tails = tf.gather(beam_tails, unfinished_beam_indices)
                 unfinished_beam_probs = tf.gather(beam_probs, unfinished_beam_indices)
                 unfinished_beam_lstm_states = tuple(
-                    tf.contrib.rnn.LSTMStateTuple(
+                    tf.compat.v1.nn.rnn_cell.LSTMStateTuple(
                         tf.gather(state_tuple.c, unfinished_beam_indices),
                         tf.gather(state_tuple.h, unfinished_beam_indices)
                     ) for state_tuple in beam_state_stack)
@@ -227,7 +228,7 @@ class DSLstmExtrapolator(modelbase.DSModelBase):
                 logical_beam_pred = tf.cast(tf.argmax(logical_beam_pred, axis=1), tf.int32)
 
                 # -- Flatten and k-max lexical beam predictions
-                lexical_beam_pred = tf.log(lexical_beam_pred) + tf.reshape(unfinished_beam_probs, shape=(-1, 1))
+                lexical_beam_pred = tf.math.log(lexical_beam_pred) + tf.reshape(unfinished_beam_probs, shape=(-1, 1))
                 lexical_beam_pred = tf.reshape(lexical_beam_pred, shape=(-1,))
                 unfinished_beam_probs, top_lexical_beam_pred_ids = tf.nn.top_k(lexical_beam_pred, k=num_unfinished_beams, sorted=False)
 
@@ -269,7 +270,7 @@ class DSLstmExtrapolator(modelbase.DSModelBase):
                     tf.tile([0], [num_finished_beams])
                 ], axis=0), shape=(self.extrapolation_beam_count,))
                 beam_state_stack = tuple(
-                    tf.contrib.rnn.LSTMStateTuple(
+                    tf.compat.v1.nn.rnn_cell.LSTMStateTuple(
                         tf.gather(state_tuple.c, padded_top_beam_pred_ids),
                         tf.gather(state_tuple.h, padded_top_beam_pred_ids)
                     ) for state_tuple in beam_state_stack)

--- a/modules/deepspell/models/modelbase.py
+++ b/modules/deepspell/models/modelbase.py
@@ -8,6 +8,7 @@ import sys
 import time
 
 import tensorflow as tf
+tf.compat.v1.disable_eager_execution()
 
 # ============================[ Local Imports ]==========================
 
@@ -63,13 +64,13 @@ class DSModelBase:
         # -- Create basic Tensor Flow nodes
         self.graph = tf.Graph()
         with self.graph.as_default():
-            self.session = tf.Session()
-            self.tf_lexical_logical_embeddings_per_timestep_per_batch = tf.placeholder(
+            self.session = tf.compat.v1.Session()
+            self.tf_lexical_logical_embeddings_per_timestep_per_batch = tf.compat.v1.placeholder(
                 tf.float32,
                 [None, None, self.num_logical_features + self.num_lexical_features])
             self.tf_lexical_logical_embeddings_per_timestep_per_batch_shape = tf.shape(
                 self.tf_lexical_logical_embeddings_per_timestep_per_batch)
-            self.tf_timesteps_per_batch = tf.placeholder(tf.int32, [None])
+            self.tf_timesteps_per_batch = tf.compat.v1.placeholder(tf.int32, [None])
             self.tf_saver = None
 
     def name(self):
@@ -80,8 +81,8 @@ class DSModelBase:
     def _finish_init_base(self):
         # Create saver only after the graph is initialized
         with self.graph.as_default():
-            self.tf_saver = tf.train.Saver()
-            self.tf_init_op = tf.global_variables_initializer()
+            self.tf_saver = tf.compat.v1.train.Saver()
+            self.tf_init_op = tf.compat.v1.global_variables_initializer()
             self.session.run(self.tf_init_op)
             print("Compute Graph Initialized.")
             print(" Trainable Variables:", tf.trainable_variables())

--- a/modules/deepspell_optimization/models/discriminator.py
+++ b/modules/deepspell_optimization/models/discriminator.py
@@ -3,6 +3,7 @@
 # ===============================[ Imports ]=============================
 
 import tensorflow as tf
+tf.compat.v1.disable_eager_execution()
 
 # ============================[ Local Imports ]==========================
 
@@ -65,23 +66,18 @@ class DSLstmDiscriminatorOptimizer(optimizer.DSModelOptimizerMixin, discriminato
                                                            :, :, -self.num_logical_features:]
 
             # -- Obtain global training step
-            global_step = tf.contrib.framework.get_global_step()
+            global_step = tf.compat.v1.train.get_or_create_global_step()
 
             # -- Calculate the average cross entropy for the logical classes per timestep
             tf_logical_loss = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(
                 labels=tf_logical_embeddings_per_timestep_per_batch,
                 logits=self.tf_logical_predictions_per_timestep_per_batch,
-                dim=2))
+                axis=2))
 
             # -- Create summaries for TensorBoard
-            tf_logical_loss_summary = tf.summary.scalar("logical_loss", tf_logical_loss)
+            tf_logical_loss_summary = tf.compat.v1.summary.scalar("logical_loss", tf_logical_loss)
 
             # -- Define training op
-            tf_optimizer = tf.train.RMSPropOptimizer(self.tf_learning_rate)
-            tf_train_op = tf.contrib.layers.optimize_loss(
-                loss=tf_logical_loss,
-                global_step=global_step,
-                learning_rate=None,
-                summaries=[],
-                optimizer=tf_optimizer)
+            tf_optimizer = tf.compat.v1.train.RMSPropOptimizer(self.tf_learning_rate)
+            tf_train_op = tf_optimizer.minimize(tf_logical_loss, global_step=global_step)
         return tf_train_op, tf_logical_loss_summary

--- a/modules/deepspell_optimization/models/encoder.py
+++ b/modules/deepspell_optimization/models/encoder.py
@@ -4,6 +4,7 @@
 
 import numpy as np
 import tensorflow as tf
+tf.compat.v1.disable_eager_execution()
 
 # ============================[ Local Imports ]==========================
 
@@ -132,16 +133,16 @@ class DSVariationalLstmAutoEncoderOptimizer(optimizer.DSModelOptimizerMixin, enc
         :return: tf_eol_char_id, tf_unk_char_id, tf_start_char_id, tf_correct_decoder_output, tf_stepwise_decoder_output
         """
         with tf.variable_scope('stepwise_decoder'):
-            tf_eol_char_id = tf.placeholder(tf.int32, shape=[])
-            tf_unk_char_id = tf.placeholder(tf.int32, shape=[])
-            tf_start_char_id = tf.placeholder(tf.int32, shape=[])
-            tf_correct_decoder_output = tf.placeholder(
+            tf_eol_char_id = tf.compat.v1.placeholder(tf.int32, shape=[])
+            tf_unk_char_id = tf.compat.v1.placeholder(tf.int32, shape=[])
+            tf_start_char_id = tf.compat.v1.placeholder(tf.int32, shape=[])
+            tf_correct_decoder_output = tf.compat.v1.placeholder(
                 dtype=tf.float32,
                 shape=(None, None, self.featureset.num_lexical_features()))
             tf_batch_size = tf.shape(tf_correct_decoder_output)[0]
-            tf_decoder_cell = tf.contrib.rnn.OutputProjectionWrapper(
-                tf.contrib.rnn.MultiRNNCell([
-                    tf.contrib.rnn.BasicLSTMCell(hidden_state_size) for hidden_state_size in
+            tf_decoder_cell = tf.compat.v1.nn.rnn_cell.OutputProjectionWrapper(
+                tf.compat.v1.nn.rnn_cell.MultiRNNCell([
+                    tf.compat.v1.nn.rnn_cell.BasicLSTMCell(hidden_state_size) for hidden_state_size in
                     self.decoder_state_size_per_layer]),
                 self.featureset.num_lexical_features())
 
@@ -153,7 +154,7 @@ class DSVariationalLstmAutoEncoderOptimizer(optimizer.DSModelOptimizerMixin, enc
                     tf_decoder_initial_state = self._prelu(tf.matmul(self.tf_latent_random_vectors, tf_w) + tf_b)
                     tf_decoder_initial_state_tuple_list, pos_in_state = [], 0
                     for state_size in self.decoder_state_size_per_layer:
-                        tf_decoder_initial_state_tuple_list += [tf.contrib.rnn.LSTMStateTuple(
+                        tf_decoder_initial_state_tuple_list += [tf.compat.v1.nn.rnn_cell.LSTMStateTuple(
                             tf_decoder_initial_state[:, pos_in_state:pos_in_state+state_size],
                             tf_decoder_initial_state[:, pos_in_state+state_size:pos_in_state+2*state_size])]
                         pos_in_state += state_size*2  # *2 for state+mem
@@ -171,7 +172,7 @@ class DSVariationalLstmAutoEncoderOptimizer(optimizer.DSModelOptimizerMixin, enc
                 return t < tf_max_decoder_steps
 
             def iteration(t, prev_output, state, stepwise_decoder_output):
-                input_keep_prob = tf.random_uniform([], .0, 1.)
+                input_keep_prob = tf.random.uniform([], .0, 1.)
                 prev_output = tf.cond(
                     tf.logical_and(input_keep_prob > self.decoder_input_keep_prob, t > 0),
                     lambda: tf.reshape(tf.tile(
@@ -198,24 +199,19 @@ class DSVariationalLstmAutoEncoderOptimizer(optimizer.DSModelOptimizerMixin, enc
         """
         with tf.name_scope("decoder_optimizer"):
             # -- Obtain global training step
-            global_step = tf.contrib.framework.get_global_step()
+            global_step = tf.compat.v1.train.get_or_create_global_step()
 
             # -- Calculate the average cross entropy for the lexical classes per timestep
             tf_lexical_loss = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(
                 labels=self.tf_correct_decoder_output,
                 logits=self.tf_stepwise_decoder_output,
-                dim=2))
+                axis=2))
 
             # -- Create summaries for TensorBoard
-            tf_lexical_loss_summary = tf.summary.scalar("lexical_loss", tf_lexical_loss)
+            tf_lexical_loss_summary = tf.compat.v1.summary.scalar("lexical_loss", tf_lexical_loss)
 
             # -- Define training op
-            tf_optimizer = tf.train.RMSPropOptimizer(self.tf_learning_rate)
-            tf_train_op = tf.contrib.layers.optimize_loss(
-                loss=tf_lexical_loss + self.tf_kl_loss,
-                global_step=global_step,
-                learning_rate=None,
-                summaries=[],
-                optimizer=tf_optimizer)
+            tf_optimizer = tf.compat.v1.train.RMSPropOptimizer(self.tf_learning_rate)
+            tf_train_op = tf_optimizer.minimize(tf_lexical_loss + self.tf_kl_loss, global_step=global_step)
 
         return tf_train_op, tf_lexical_loss_summary

--- a/modules/deepspell_optimization/models/extrapolator.py
+++ b/modules/deepspell_optimization/models/extrapolator.py
@@ -3,6 +3,7 @@
 # ===============================[ Imports ]=============================
 
 import tensorflow as tf
+tf.compat.v1.disable_eager_execution()
 
 # ============================[ Local Imports ]==========================
 
@@ -54,7 +55,7 @@ class DSLstmExtrapolatorOptimizer(optimizer.DSModelOptimizerMixin, extrapolator.
     def _extrapolator_optimizer(self):
         with tf.name_scope("extrapolator_optimizer"):
             # -- Obtain global training step
-            global_step = tf.contrib.framework.get_global_step()
+            global_step = tf.compat.v1.train.get_or_create_global_step()
 
             # -- Time indices are sliced as follows:
             #  For labels: First Input can be ignored
@@ -67,24 +68,19 @@ class DSLstmExtrapolatorOptimizer(optimizer.DSModelOptimizerMixin, extrapolator.
             tf_logical_loss = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(
                  labels=self.tf_lexical_logical_embeddings_per_timestep_per_batch[:, 1:, -self.num_logical_features:],
                  logits=self.tf_lexical_logical_predictions_per_timestep_per_batch[:, :-1, -self.num_logical_features:],
-                 dim=2))
+                 axis=2))
 
             # -- Calculate the average cross entropy for the lexical classes per timestep
             tf_lexical_loss = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(
                 labels=self.tf_lexical_logical_embeddings_per_timestep_per_batch[:, 1:, :self.num_lexical_features],
                 logits=self.tf_lexical_logical_predictions_per_timestep_per_batch[:, :-1, :self.num_lexical_features],
-                dim=2))
+                axis=2))
 
             # -- Create summaries for TensorBoard
-            tf_logical_loss_summary = tf.summary.scalar("logical_loss", tf_logical_loss)
-            tf_lexical_loss_summary = tf.summary.scalar("lexical_loss", tf_lexical_loss)
+            tf_logical_loss_summary = tf.compat.v1.summary.scalar("logical_loss", tf_logical_loss)
+            tf_lexical_loss_summary = tf.compat.v1.summary.scalar("lexical_loss", tf_lexical_loss)
 
             # -- Define training op
-            tf_optimizer = tf.train.RMSPropOptimizer(self.tf_learning_rate)
-            tf_train_op = tf.contrib.layers.optimize_loss(
-                loss=tf_logical_loss+tf_lexical_loss,
-                global_step=global_step,
-                learning_rate=None,
-                summaries=[],
-                optimizer=tf_optimizer)
+            tf_optimizer = tf.compat.v1.train.RMSPropOptimizer(self.tf_learning_rate)
+            tf_train_op = tf_optimizer.minimize(tf_logical_loss+tf_lexical_loss, global_step=global_step)
         return tf_train_op, tf_logical_loss_summary, tf_lexical_loss_summary

--- a/modules/deepspell_optimization/models/optimizer.py
+++ b/modules/deepspell_optimization/models/optimizer.py
@@ -8,6 +8,7 @@ import sys
 import time
 
 import tensorflow as tf
+tf.compat.v1.disable_eager_execution()
 
 from deepspell import corpus, grammar
 from deepspell.models import modelbase
@@ -71,7 +72,7 @@ class DSModelOptimizerMixin(modelbase.DSModelBase):
         self.training_history = args.pop("training_history", [])
         self.tf_summary_writer = None
         with self.graph.as_default():
-            self.tf_learning_rate = tf.placeholder(tf.float32)
+            self.tf_learning_rate = tf.compat.v1.placeholder(tf.float32)
 
     def store(self, file=None):
         """
@@ -157,7 +158,7 @@ class DSModelOptimizerMixin(modelbase.DSModelBase):
             print("------------------------------------------------------")
             current_learning_rate = self.learning_rate
             if os.path.isdir(self.log_dir):
-                self.tf_summary_writer = tf.summary.FileWriter(os.path.join(self.log_dir, self.name()))
+                self.tf_summary_writer = tf.compat.v1.summary.FileWriter(os.path.join(self.log_dir, self.name()))
                 self.tf_summary_writer.add_graph(self.graph)
             else:
                 print("No valid log dir issued. Log will not be written!")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow==1.9
+tensorflow>=2.13
 unidecode
 flask
 scipy==1.1.0

--- a/tf-rename-variables.py
+++ b/tf-rename-variables.py
@@ -1,6 +1,7 @@
 import sys, getopt
 
 import tensorflow as tf
+tf.compat.v1.disable_eager_execution()
 
 usage_str = 'python tensorflow_rename_variables.py --checkpoint_dir=path/to/dir/ ' \
             '--replace_from=substr --replace_to=substr --add_prefix=abc --dry_run'
@@ -8,10 +9,10 @@ usage_str = 'python tensorflow_rename_variables.py --checkpoint_dir=path/to/dir/
 
 def rename(checkpoint_dir, replace_from, replace_to, add_prefix, dry_run):
     checkpoint = tf.train.get_checkpoint_state(checkpoint_dir)
-    with tf.Session() as sess:
-        for var_name, _ in tf.contrib.framework.list_variables(checkpoint_dir):
+    with tf.compat.v1.Session() as sess:
+        for var_name, _ in tf.train.list_variables(checkpoint_dir):
             # Load the variable
-            var = tf.contrib.framework.load_variable(checkpoint_dir, var_name)
+            var = tf.train.load_variable(checkpoint_dir, var_name)
 
             # Set the new name
             new_name = var_name
@@ -32,8 +33,8 @@ def rename(checkpoint_dir, replace_from, replace_to, add_prefix, dry_run):
 
         if not dry_run:
             # Save the variables
-            saver = tf.train.Saver()
-            sess.run(tf.global_variables_initializer())
+            saver = tf.compat.v1.train.Saver()
+            sess.run(tf.compat.v1.global_variables_initializer())
             saver.save(sess, checkpoint_dir)
 
 


### PR DESCRIPTION
## Summary
- require TensorFlow 2 in requirements
- disable eager execution for all TensorFlow modules
- switch `tf.contrib` calls to `tf.compat.v1` equivalents
- use `tf.compat.v1` APIs for sessions, placeholders, savers, etc.
- replace deprecated ops such as `tf.log` and `tf.random_normal`
- update variable rename helper for TF2

## Testing
- `python -m py_compile $(git ls-files '*.py')`